### PR TITLE
Reconnection fixes

### DIFF
--- a/polo-common/src/main/java/dev/dhdf/polo/webclient/WebClient.java
+++ b/polo-common/src/main/java/dev/dhdf/polo/webclient/WebClient.java
@@ -146,6 +146,9 @@ public class WebClient {
                 logger.error("An invalid endpoint was called for.");
                 return null;
             }
+        } catch (java.net.ConnectException e) {
+            logger.warn(e.getMessage());
+            return null;
         } catch (IOException | JSONException | NullPointerException e) {
             e.printStackTrace();
             return null;

--- a/polo-common/src/main/java/dev/dhdf/polo/webclient/WebClient.java
+++ b/polo-common/src/main/java/dev/dhdf/polo/webclient/WebClient.java
@@ -65,6 +65,8 @@ public class WebClient {
                 "/chat",
                 null
         );
+        if (chatResponse == null)
+            return;
         JSONArray messages = chatResponse.getJSONArray("chat");
 
         // Send all the new messages to the minecraft chat


### PR DESCRIPTION
A couple of minor fixes for your consideration.

The first fixes the null dereference when connection to appservice is refused, which seems to prevent the poll timer retriggering.

The second just quietens the output a bit for refused connections, so as not to fill the server log with backtraces when the problem is probably on the appservice side and probably temporary.