### PR TITLE
Fix timer period to 5sec instead of >4mins

### DIFF
--- a/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/Main.java
+++ b/polo-bukkit/src/main/java/dev/dhdf/polo/bukkit/Main.java
@@ -59,7 +59,7 @@ public class Main extends JavaPlugin implements PoloPlugin {
         if (vibeCheck) {
             logger.finer("Started bridge");
             Sync sync = new Sync(webClient);
-            getServer().getScheduler().runTaskTimerAsynchronously(this, sync, 0, 5000);
+            getServer().getScheduler().runTaskTimerAsynchronously(this, sync, 0, 5*20);
         } else {
             logger.severe("Couldn't properly connect to marco is the address and port set properly?");
         }


### PR DESCRIPTION
Commit d287654a23c7 ("Use the scheduler provided by the API for Sync")
switched to using runTaskTimerAsynchronously(), but it appears that the
period is measured in ticks, not milliseconds, so the value of
5000 is actually over 4 minutes. This causes long delays for MX->MC
messages to get through.

Fix it to 5*20 ticks, 5 seconds. I'm assuming ticks are always at a rate
of about 20Hz, since I can't find any API to get the tick rate and from
what I've read its not configurable.

The relevant documentation which seems to still apply is here:
https://jd.bukkit.org/org/bukkit/scheduler/BukkitScheduler.html#runTaskTimerAsynchronously(org.bukkit.plugin.Plugin,%20java.lang.Runnable,%20long,%20long)

Fixes: d287654a23c7 ("Use the scheduler provided by the API for Sync")